### PR TITLE
Fix container paths, moving asadmin to front

### DIFF
--- a/tasks/include_startdomain.yml
+++ b/tasks/include_startdomain.yml
@@ -12,7 +12,7 @@
 
 - name: "{{ play_name }}Checking {{ container_domain }}"
   environment:
-    PATH: "{{ ansible_env.PATH }}:{{ container_path }}/bin"
+    PATH: "{{ container_path }}/bin:{{ ansible_env.PATH }}"
   command: "nohup asadmin list-domains"
   when: check_ctr.stat.exists == true
   register: check_ctr_doms
@@ -23,7 +23,7 @@
 
 - name: "{{ play_name }}Starting {{ container_domain }}"
   environment:
-    PATH: "{{ ansible_env.PATH }}:{{ container_path }}/bin"
+    PATH: "{{ container_path }}/bin:{{ ansible_env.PATH }}"
   command: "nohup {{ item }}"
   with_items:
     - "asadmin start-domain {{ container_domain }}"

--- a/tasks/setup_container.yml
+++ b/tasks/setup_container.yml
@@ -36,13 +36,13 @@
 
 - name: "{{ play_name }}Stopping {{ container_domain }}"
   environment:
-    PATH: "{{ ansible_env.PATH }}:{{ container_path }}/bin"
+    PATH: "{{ container_path }}/bin:{{ ansible_env.PATH }}"
   command: "nohup asadmin stop-domain {{ container_domain }}"
   when: ctr_dom.stat.exists == true
 
 - name: "{{ play_name }}Running setup script"
   environment:
-    PATH: "{{ ansible_env.PATH }}:{{ container_path }}/bin"
+    PATH: "{{ container_path }}/bin:{{ ansible_env.PATH }}"
   command: "python {{ user_home }}/setup-glassfish.py {{ container_domain }} 75% {{ mysql_root_pass }}"
   tags:
     - install
@@ -65,7 +65,7 @@
 
 - name: "{{ play_name }}Restarting {{ container_domain }}"
   environment:
-    PATH: "{{ ansible_env.PATH }}:{{ container_path }}/bin"
+    PATH: "{{ container_path }}/bin:{{ ansible_env.PATH }}"
   command: "nohup {{ item }}"
   with_items:
   - "asadmin restart-domain {{ container_domain }}"

--- a/tasks/setup_ids_server.yml
+++ b/tasks/setup_ids_server.yml
@@ -136,7 +136,7 @@
 
 - name: "{{ play_name }}Installing IDS"
   environment:
-    PATH: "{{ ansible_env.PATH }}:{{ container_path }}/bin"
+    PATH: "{{ container_path }}/bin:{{ ansible_env.PATH }}"
   shell:
     cmd: ./setup install
     chdir: "{{ ids_path }}"

--- a/tasks/setup_topcat.yml
+++ b/tasks/setup_topcat.yml
@@ -229,7 +229,7 @@
 
 - name: "{{ play_name }}Installing TopCat"
   environment:
-    PATH: "{{ ansible_env.PATH }}:{{ container_path }}/bin"
+    PATH: "{{ container_path }}/bin:{{ ansible_env.PATH }}"
   shell:
     cmd: ./setup install
     chdir: "{{ topcat_path }}"


### PR DESCRIPTION
This should mean that the "asadmin" calls in the ainsible build pick up the container's asadmin rather than, say, /usr/bin/adamin (as happens on OpenStack VMs at present).